### PR TITLE
docs: adding possibility to install from winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The default location of the executable is `%USERPROFILE%\scoop\apps\servicebusex
 curl -s https://api.github.com/repos/paolosalvatori/ServiceBusExplorer/releases/latest | grep browser_download_url | cut -d '"' -f 4
 ```
 
+## Using [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
+
+````
+winget install --id paolosalvatori.ServiceBusExplorer --source winget
+````
+
 # Contributions
 There are no dedicated developers so development is entirely based on voluntary effort.
 


### PR DESCRIPTION
This pull request updates the `README.md` file to include installation instructions using Winget, Microsoft's package manager for Windows.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60-R65): Added a new section titled "Using Winget" with a command example to install the ServiceBusExplorer directly via Winget.